### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .venv
 .DS_Store
 .vscode/
+redux-review-app


### PR DESCRIPTION
Add `redux-review-app` to `.gitignore` so that the redux-review-app can be safely stored in the root of our project